### PR TITLE
feat: add an `exitOnEnter` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ console.log(`Hellou ${guest || 'Stranger'}`);
 //=> 'Hellou Deno'
 ```
 
+### You can read whole files from stdin too
+
+```ts
+// example.ts
+import { getStdin } from 'deno.land/x/get_stdin/mod.ts';
+
+const input = await getStdin({ exitOnEnter: false })
+
+console.log(`Received a bunch of (possibly) multiline text from stdin:\n${input}`)
+```
+
+```sh
+$ echo lots\nof\nstuff\nhere > example.txt
+$ cat example.txt | deno run example.ts
+lots
+of
+stuff
+here
+```
+
 ## API
 
 ### getStdin(options?: GetStdinOptions)

--- a/README.md
+++ b/README.md
@@ -56,21 +56,25 @@ console.log(`Hellou ${guest || 'Stranger'}`);
 
 ## API
 
-### getStdin()
+### getStdin(options?: GetStdinOptions)
 
 Get `stdin` as a `string`.
 
-### getStdinBuffer()
+### getStdinBuffer(options?: GetStdinOptions)
 
 Get `stdin` as a `Buffer`.
 
-### getStdinSync()
+### getStdinSync(options?: GetStdinOptions)
 
 Get `stdin` as a `string` in sync mode.
 
-### getStdinBufferSync()
+### getStdinBufferSync(options?: GetStdinOptions)
 
 Get `stdin` as a `Buffer` in sync mode.
+
+### GetStdinOptions
+
+- `exitOnEnter` (optional) - If `true`, stop reading the stdin once a newline char is reached. Defaults to `true`.
 
 ## Inspired
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ console.log(`Hellou ${guest || 'Stranger'}`);
 // example.ts
 import { getStdin } from 'deno.land/x/get_stdin/mod.ts';
 
-const input = await getStdin({ exitOnEnter: false })
+const input = await getStdin({ exitOnEnter: false });
 
-console.log(`Received a bunch of (possibly) multiline text from stdin:\n${input}`)
+console.log(`Received a bunch of (possibly) multiline text from stdin:\n${input}`);
 ```
 
 ```sh

--- a/mod.ts
+++ b/mod.ts
@@ -1,9 +1,19 @@
 const decoder = new TextDecoder();
 
+interface GetStdinOptions {
+  /**
+   * If `true`, stop reading the stdin once a newline char is reached
+   * @default true
+   */
+  exitOnEnter?: boolean;
+}
+
 /**
  * Returns an Uint8Array from standard input
  */
-export async function getStdinBuffer(): Promise<Uint8Array> {
+export async function getStdinBuffer(
+  options: GetStdinOptions = {}
+): Promise<Uint8Array> {
   const bytes: number[] = [];
 
   while (true) {
@@ -18,8 +28,8 @@ export async function getStdinBuffer(): Promise<Uint8Array> {
 
     const byte = buffer[0];
 
-    // On Enter, exit
-    if (byte === 10) {
+    // On Enter, exit if we are supposed to
+    if (byte === 10 && options.exitOnEnter !== false) {
       break;
     }
 
@@ -32,8 +42,8 @@ export async function getStdinBuffer(): Promise<Uint8Array> {
 /**
  * Returns a string from standard input
  */
-export async function getStdin(): Promise<string> {
-  const buffer = await getStdinBuffer();
+export async function getStdin(options: GetStdinOptions = {}): Promise<string> {
+  const buffer = await getStdinBuffer(options);
 
   return decoder.decode(buffer);
 }
@@ -41,7 +51,7 @@ export async function getStdin(): Promise<string> {
 /**
  * Returns an Uint8Array from standard input in sync mode
  */
-export function getStdinBufferSync(): Uint8Array {
+export function getStdinBufferSync(options: GetStdinOptions = {}): Uint8Array {
   const bytes: number[] = [];
 
   while (true) {
@@ -56,8 +66,8 @@ export function getStdinBufferSync(): Uint8Array {
 
     const byte = buffer[0];
 
-    // On Enter, exit
-    if (byte === 10) {
+    // On Enter, exit if we are supposed to
+    if (byte === 10 && options.exitOnEnter !== false) {
       break;
     }
 
@@ -70,8 +80,8 @@ export function getStdinBufferSync(): Uint8Array {
 /**
  * Returns a string from standard input in sync mode
  */
-export function getStdinSync(): string {
-  const buffer = getStdinBufferSync();
+export function getStdinSync(options: GetStdinOptions = {}): string {
+  const buffer = getStdinBufferSync(options);
 
   return decoder.decode(buffer);
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 const decoder = new TextDecoder();
 
-interface GetStdinOptions {
+export interface GetStdinOptions {
   /**
    * If `true`, stop reading the stdin once a newline char is reached
    * @default true


### PR DESCRIPTION
Adds an `exitOnEnter` option to all four of the function exported by `mod.ts`.

To preserve backward compatibility, the new `options` parameter is optional, and the default value of `exitOnEnter` is `true`, the previous behavior.